### PR TITLE
Use supplied binary in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ bundle exec ruby validate.rb
 ###Codeship Deploy Commands:
 
 ```
-bash deploy.sh
+bundle exec dns_deploy records.json
 ```
 
 ###DNSimple credentials


### PR DESCRIPTION
I noticed in the README, that an unknown shell script was referenced, when the gem seems to come with a binary. So I changed the example to use the binary that is supplied by the gem.
